### PR TITLE
CLI: Make sure queries are limited to 100 and warn the user

### DIFF
--- a/inc/class.dmg-read-more-cli.php
+++ b/inc/class.dmg-read-more-cli.php
@@ -90,6 +90,12 @@ class Dmg_Read_More_CLI {
 		// Set the limit for the number of results.
 		if ( isset( $assoc_args['limit'] ) ) {
 			$this->limit = WP_CLI\Utils\get_flag_value( $assoc_args, 'limit' );
+
+			// If the limit is greater than 100, tell the user it will be set to 100.
+			if ( $this->limit > 100 || $this->limit < 0 ) {
+				WP_CLI::warning( 'You have specified a limit greater than 100. This will be forced back to 100 to avoid bad things happening.' );
+				$this->limit = 100;
+			}
 		}
 
 		// Set the offset for pagination.


### PR DESCRIPTION
This change introduces a hard-coded limit of 100 posts on the query. If the user tries to get more than 100 posts the hard limit is activated and a warning is printed to the user to let them know that there won't be as many results as they've asked for.